### PR TITLE
changed hash function of Token -> set is working properly

### DIFF
--- a/Data.py
+++ b/Data.py
@@ -44,10 +44,6 @@ class Token:
         if isinstance(obj, self.__class__) and obj.content == self.content:
                 return True
         return False
-    def __hash__(self):
-        md5HashGenerator = md5()
-        md5HashGenerator.update(bytes(self.content, "utf-8"))
-        return bytesToInt(md5HashGenerator.digest())
 
     def compare(self, local, other):
         if isinstance(local, Addition):
@@ -88,6 +84,7 @@ class FileToken(Token):
             self.binary = False
         else:
             self.binary = True
+
     def __hash__(self):
         md5HashGenerator = md5()
         md5HashGenerator.update(bytes(self.content, "utf-8"))
@@ -99,6 +96,8 @@ class FileToken(Token):
 #        return False
 
     def compare(self, local, other):
+        print(local)
+        print(other)
         if isinstance(local, Addition):
             if isinstance(other, Addition):
                 if(other == local):

--- a/Data.py
+++ b/Data.py
@@ -90,7 +90,7 @@ class FileToken(Token):
             self.binary = True
     def __hash__(self):
         md5HashGenerator = md5()
-        md5HashGenerator.update(bytes(self.fileSystem.absPath(self.content), "utf-8"))
+        md5HashGenerator.update(bytes(self.content, "utf-8"))
         return bytesToInt(md5HashGenerator.digest())
 
 #    def __eq__(self, obj):

--- a/FileSystem.py
+++ b/FileSystem.py
@@ -37,7 +37,6 @@ class FileSystem:
         return allFiles
 
     def readFile(self, path):
-        print(path)
         textAsToken = list()
         try:
             file = open(self.absPath(path), "r")

--- a/Main.py
+++ b/Main.py
@@ -115,9 +115,7 @@ if __name__ == "__main__":
     dirResult = threeWayMerge(localDir.readDir(exclude=hiddenDirName), otherDir.readDir(), baseDir.readDir())
     for result in dirResult:
         if isinstance(result, Token):
-            continue
-        elif (result.token.binary):
-            continue
+            pass
         elif isinstance(result, Conflict):
             print("There is a error for these two files:")
             print("\t(1)" + result.tokenLocal.content)
@@ -156,9 +154,6 @@ if __name__ == "__main__":
         localTokenList = localDir.readFile(filePath.content)
         otherTokenList = otherDir.readFile(filePath.content)
         baseTokenList = baseDir.readFile(filePath.content)
-
-        if(localTokenList is None or otherTokenList is None or baseTokenList is None):
-            continue
 
         if localTokenList == otherTokenList:
             if otherTokenList == baseTokenList:

--- a/Main.py
+++ b/Main.py
@@ -94,7 +94,6 @@ def initialize(targetPath):
 def commonList(listA, listB, key=lambda obj: obj):
     setA = set(listA)
     setB = set(listB)
-
     return list(setA & setB)
 
 if __name__ == "__main__":
@@ -151,7 +150,7 @@ if __name__ == "__main__":
                 baseDir.remove(token.content)
 
     #remove files, which were not copied before
-    filePaths = commonList(localDir.readDir(exclude=hiddenDirName), otherDir.readDir())
+    filePaths = commonList(localDir.readDir(exclude=hiddenDirName), otherDir.readDir(), key=lambda token:token.content)
 
     for filePath in filePaths:
         localTokenList = localDir.readFile(filePath.content)
@@ -171,12 +170,14 @@ if __name__ == "__main__":
             for token in merged:
                 if isinstance(token, Conflict):
                     ## TODO: improve Conflict handling
-                    print("There is a merge conflict in the file " + filePath)
-                    print("Absolute paths:\n\t(1) " + localDir.absPath(filePath) + "\n\t(2) " + otherDir.absPath(filePath))
-                    continue
-            localDir.write(filePath.content, merged)
-            otherDir.write(filePath.content, merged)
-            baseDir.write(filePath.content, merged)
+                    conflict = token
+                    print("There is a merge conflict in the file " + str(filePath.content))
+                    print("Absolute paths:\n\t(1) " + localDir.absPath(filePath.content) + "\n\t(2) " + otherDir.absPath(filePath.content))
+                    break
+            else: #only commit changes, if there is no conflict
+                localDir.write(filePath.content, merged)
+                otherDir.write(filePath.content, merged)
+                baseDir.write(filePath.content, merged)
 
 
 def copy(srcFileSystem, dstFileSystem, relPath):


### PR DESCRIPTION
The Merging was not working anymore(#3), because the hash function of the tokens, created the hash from the absolute file path. When comparing the two paths in the Main.py(line 153) they were always different, because the absolute path differs, so that all files got sorted out for merging.

Now the hash function of the Token only relies on the relative path and you can compare files from different absolute locations on base of their relative location.